### PR TITLE
OY-5112 Downgreidattu postgres-ajuri

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,8 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.7.5</version>
+                <!-- versio 42.7.5 aiheuttaa tiettyjen laskentojen jumiutumisen, ennen päivitystä ks. tiketti OY-5125 testausohjeita varten -->
+                <version>42.7.3</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
  - päivitys versioon 42.7.5 aiheuttaa tiettyjen laskentojen jumiutumisen jonosijojen tallennukseen, ks. tiketti OY-5125