### PR TITLE
OY-5200 historiadata siirtotiedostoon

### DIFF
--- a/valintalaskenta-domain/src/main/java/fi/vm/sade/valintalaskenta/domain/valintakoe/Hakutoive.java
+++ b/valintalaskenta-domain/src/main/java/fi/vm/sade/valintalaskenta/domain/valintakoe/Hakutoive.java
@@ -18,7 +18,6 @@ public class Hakutoive {
   @Transient
   @Column("valintakoe_osallistuminen")
   private ValintakoeOsallistuminen valintakoeOsallistuminen;
-  
 
   public Hakutoive() {}
 

--- a/valintalaskenta-domain/src/main/java/fi/vm/sade/valintalaskenta/domain/valintakoe/Hakutoive.java
+++ b/valintalaskenta-domain/src/main/java/fi/vm/sade/valintalaskenta/domain/valintakoe/Hakutoive.java
@@ -18,8 +18,7 @@ public class Hakutoive {
   @Transient
   @Column("valintakoe_osallistuminen")
   private ValintakoeOsallistuminen valintakoeOsallistuminen;
-
-  private Date createdAt;
+  
 
   public Hakutoive() {}
 
@@ -63,14 +62,6 @@ public class Hakutoive {
   public void setValintakoeValinnanvaiheet(Set<ValintakoeValinnanvaihe> valintakoeValinnanvaiheet) {
     this.valintakoeValinnanvaiheet.clear();
     this.valintakoeValinnanvaiheet.addAll(valintakoeValinnanvaiheet);
-  }
-
-  public Date getCreatedAt() {
-    return createdAt;
-  }
-
-  public void setCreatedAt(Date createdAt) {
-    this.createdAt = createdAt;
   }
 
   @Override


### PR DESCRIPTION
created_at -aikaleima jäi puuttumaan valintakoeosallistumisista myös uudessa datassa, ongelma ilmeni kun kenttä accessoreilla lisättiin domain-entiteettiin mikä nähtävästi estää kannan autogeneroiman aikaleiman syntymisen.